### PR TITLE
Allow searching by album.

### DIFF
--- a/Sources/LyricsService/Lyrics+Quality.swift
+++ b/Sources/LyricsService/Lyrics+Quality.swift
@@ -70,7 +70,7 @@ extension Lyrics {
           if let searchAlbum = searchAlbum {
               return similarity(s1: album, s2: searchAlbum)
           } else {
-              return 1 - qualityMixBound
+              return qualityMixBound - 1
           }
       case let .keyword(keyword)?:
           if keyword.contains(album) { return matchedAlbumFactor }

--- a/Sources/LyricsService/LyricsSearchRequest.swift
+++ b/Sources/LyricsService/LyricsSearchRequest.swift
@@ -18,7 +18,7 @@ public struct LyricsSearchRequest: Equatable {
     
     public enum SearchTerm: Equatable {
         case keyword(String)
-        case info(title: String, artist: String)
+        case info(title: String, artist: String, album: String? = nil)
     }
     
     public init(searchTerm: SearchTerm, duration: TimeInterval, limit: Int = 6, userInfo: [String: String] = [:]) {
@@ -35,8 +35,8 @@ extension LyricsSearchRequest.SearchTerm: CustomStringConvertible {
         switch self {
         case let .keyword(keyword):
             return keyword
-        case let .info(title: title, artist: artist):
-            return title + " " + artist
+        case let .info(title: title, artist: artist, album: album):
+            return title + " " + artist + (album != nil ? " \(album!)" : "")
         }
     }
 }

--- a/Sources/LyricsService/Provider/Discontinued/ViewLyrics.swift
+++ b/Sources/LyricsService/Provider/Discontinued/ViewLyrics.swift
@@ -46,7 +46,7 @@ extension LyricsProviders.ViewLyrics: _LyricsProvider {
     }
     
     public func lyricsSearchPublisher(request: LyricsSearchRequest) -> AnyPublisher<LyricsToken, Never> {
-        guard case let .info(title, artist) = request.searchTerm else {
+        guard case let .info(title, artist, _) = request.searchTerm else {
             // cannot search by keyword
             return Empty().eraseToAnyPublisher()
         }

--- a/Sources/LyricsService/Provider/Gecimi.swift
+++ b/Sources/LyricsService/Provider/Gecimi.swift
@@ -34,7 +34,7 @@ extension LyricsProviders.Gecimi: _LyricsProvider {
     public static let service: LyricsProviders.Service? = .gecimi
     
     public func lyricsSearchPublisher(request: LyricsSearchRequest) -> AnyPublisher<LyricsToken, Never> {
-        guard case let .info(title, artist) = request.searchTerm else {
+        guard case let .info(title, artist, _) = request.searchTerm else {
             // cannot search by keyword
             return Empty().eraseToAnyPublisher()
         }

--- a/Sources/LyricsService/Provider/Syair.swift
+++ b/Sources/LyricsService/Provider/Syair.swift
@@ -30,9 +30,12 @@ extension LyricsProviders.Syair: _LyricsProvider {
     public func lyricsSearchPublisher(request: LyricsSearchRequest) -> AnyPublisher<String, Never> {
         var parameter: [String: Any] = ["page": 1]
         switch request.searchTerm {
-        case let .info(title: title, artist: artist):
+        case let .info(title: title, artist: artist, album: album):
             parameter["artist"] = artist
             parameter["title"] = title
+            if let album = album {
+                parameter["album"] = album
+            }
         case let .keyword(keyword):
             parameter["q"] = keyword
         }

--- a/Tests/LyricsKitTests/LyricsKitTests.swift
+++ b/Tests/LyricsKitTests/LyricsKitTests.swift
@@ -40,4 +40,19 @@ final class LyricsKitTests: XCTestCase {
         waitForExpectations(timeout: 10)
         cancelable.cancel()
     }
+    
+    func testNetEaseAlbumSearch() {
+        let searchResultEx = expectation(description: "search succeed")
+        let provider = LyricsProviders.NetEase()
+        let searchTerm = LyricsSearchRequest.SearchTerm.info(title: "Cocoa Hooves", artist: "Glass Animals", album: "ZABA")
+        let publisher = provider.lyricsPublisher(request: .init(searchTerm: searchTerm, duration: 271))
+        let cancelable = publisher.sink { lyrics in
+            guard case let .info(title, artist, album) = searchTerm else { return }
+            if lyrics.idTags[.title] == title && lyrics.idTags[.artist] == artist && lyrics.idTags[.album] == album {
+                searchResultEx.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 10)
+        cancelable.cancel()
+    }
 }


### PR DESCRIPTION
Sometimes I have found that there are songs (or singles with features for example) that have slightly different lyrics or a different timing. 

My change allows the application to specify an album as part of the search request:

- There is now an optional `album` property that you can add when creating a `.info` search request.
- The NetEase and QQ searches will append the album name at the end of the search query.
- The `quality` of the returned lyrics will be increased if the album is matching.

I have tested and verified that adding the album to the search request significantly narrows the results and increases the `quality` value for proper matching results which makes it easier to deliver accurate lyrics to the user.